### PR TITLE
Fixes about bed colors

### DIFF
--- a/resources/mappings/preflatteningblockiddata.json
+++ b/resources/mappings/preflatteningblockiddata.json
@@ -595,62 +595,62 @@
     "legacydata": 0
   },
   {
-    "blockdata": "minecraft:red_bed[facing=south,occupied=false,part=foot]",
+    "blockdata": "minecraft:white_bed[facing=south,occupied=false,part=foot]",
     "legacyid": 26,
     "legacydata": 0
   },
   {
-    "blockdata": "minecraft:red_bed[facing=west,occupied=false,part=foot]",
+    "blockdata": "minecraft:white_bed[facing=west,occupied=false,part=foot]",
     "legacyid": 26,
     "legacydata": 1
   },
   {
-    "blockdata": "minecraft:red_bed[facing=north,occupied=false,part=foot]",
+    "blockdata": "minecraft:white_bed[facing=north,occupied=false,part=foot]",
     "legacyid": 26,
     "legacydata": 2
   },
   {
-    "blockdata": "minecraft:red_bed[facing=east,occupied=false,part=foot]",
+    "blockdata": "minecraft:white_bed[facing=east,occupied=false,part=foot]",
     "legacyid": 26,
     "legacydata": 3
   },
   {
-    "blockdata": "minecraft:red_bed[facing=south,occupied=false,part=head]",
+    "blockdata": "minecraft:white_bed[facing=south,occupied=false,part=head]",
     "legacyid": 26,
     "legacydata": 8
   },
   {
-    "blockdata": "minecraft:red_bed[facing=west,occupied=false,part=head]",
+    "blockdata": "minecraft:white_bed[facing=west,occupied=false,part=head]",
     "legacyid": 26,
     "legacydata": 9
   },
   {
-    "blockdata": "minecraft:red_bed[facing=north,occupied=false,part=head]",
+    "blockdata": "minecraft:white_bed[facing=north,occupied=false,part=head]",
     "legacyid": 26,
     "legacydata": 10
   },
   {
-    "blockdata": "minecraft:red_bed[facing=east,occupied=false,part=head]",
+    "blockdata": "minecraft:white_bed[facing=east,occupied=false,part=head]",
     "legacyid": 26,
     "legacydata": 11
   },
   {
-    "blockdata": "minecraft:red_bed[facing=south,occupied=true,part=head]",
+    "blockdata": "minecraft:white_bed[facing=south,occupied=true,part=head]",
     "legacyid": 26,
     "legacydata": 12
   },
   {
-    "blockdata": "minecraft:red_bed[facing=west,occupied=true,part=head]",
+    "blockdata": "minecraft:white_bed[facing=west,occupied=true,part=head]",
     "legacyid": 26,
     "legacydata": 13
   },
   {
-    "blockdata": "minecraft:red_bed[facing=north,occupied=true,part=head]",
+    "blockdata": "minecraft:white_bed[facing=north,occupied=true,part=head]",
     "legacyid": 26,
     "legacydata": 14
   },
   {
-    "blockdata": "minecraft:red_bed[facing=east,occupied=true,part=head]",
+    "blockdata": "minecraft:white_bed[facing=east,occupied=true,part=head]",
     "legacyid": 26,
     "legacydata": 15
   },

--- a/resources/mappings/preflatteningitemiddata.json
+++ b/resources/mappings/preflatteningitemiddata.json
@@ -2505,7 +2505,7 @@
     "legacydata": 0
   },
   {
-    "itemkey": "red_bed",
+    "itemkey": "white_bed",
     "legacyid": 355,
     "legacydata": 0
   },
@@ -2573,6 +2573,11 @@
     "itemkey": "green_bed",
     "legacyid": 355,
     "legacydata": 13
+  },
+  {
+	"itemkey": "red_bed",
+	"legacyid": 355,
+	"legacydata": 14
   },
   {
     "itemkey": "black_bed",

--- a/src/protocolsupportresourcesgenerator/generators/mappings/block/LegacyBlockDataMappingsGenerator.java
+++ b/src/protocolsupportresourcesgenerator/generators/mappings/block/LegacyBlockDataMappingsGenerator.java
@@ -518,7 +518,7 @@ public class LegacyBlockDataMappingsGenerator {
 					Material.PURPLE_BED, Material.RED_BED, Material.WHITE_BED, Material.YELLOW_BED
 				),
 				o -> {
-					Bed bed = (Bed) Material.RED_BED.createBlockData();
+					Bed bed = (Bed) Material.WHITE_BED.createBlockData();
 					bed.setFacing(o.getFacing());
 					bed.setPart(o.getPart());
 					return bed;

--- a/src/protocolsupportresourcesgenerator/generators/mappings/item/LegacyItemTypeMappingsGenerator.java
+++ b/src/protocolsupportresourcesgenerator/generators/mappings/item/LegacyItemTypeMappingsGenerator.java
@@ -117,6 +117,23 @@ public class LegacyItemTypeMappingsGenerator {
 			registerRemapEntry(Material.TRIDENT, Material.DIAMOND_HOE, ProtocolVersionsHelper.BEFORE_1_13);
 			registerRemapEntry(Material.DEBUG_STICK, Material.STICK, ProtocolVersionsHelper.BEFORE_1_13);
 
+			// Bed items remap (in order to avoid the white bed blockdata remap)
+			registerRemapEntry(Material.ORANGE_BED, Material.ORANGE_BED, ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_12, ProtocolVersion.MINECRAFT_1_12_2));
+			registerRemapEntry(Material.MAGENTA_BED, Material.MAGENTA_BED, ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_12, ProtocolVersion.MINECRAFT_1_12_2));
+			registerRemapEntry(Material.LIGHT_BLUE_BED, Material.LIGHT_BLUE_BED, ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_12, ProtocolVersion.MINECRAFT_1_12_2));
+			registerRemapEntry(Material.YELLOW_BED, Material.YELLOW_BED, ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_12, ProtocolVersion.MINECRAFT_1_12_2));
+			registerRemapEntry(Material.LIME_BED, Material.LIME_BED, ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_12, ProtocolVersion.MINECRAFT_1_12_2));
+			registerRemapEntry(Material.PINK_BED, Material.PINK_BED, ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_12, ProtocolVersion.MINECRAFT_1_12_2));
+			registerRemapEntry(Material.GRAY_BED, Material.GRAY_BED, ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_12, ProtocolVersion.MINECRAFT_1_12_2));
+			registerRemapEntry(Material.LIGHT_GRAY_BED, Material.LIGHT_GRAY_BED, ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_12, ProtocolVersion.MINECRAFT_1_12_2));
+			registerRemapEntry(Material.CYAN_BED, Material.CYAN_BED, ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_12, ProtocolVersion.MINECRAFT_1_12_2));
+			registerRemapEntry(Material.BLUE_BED, Material.BLUE_BED, ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_12, ProtocolVersion.MINECRAFT_1_12_2));
+			registerRemapEntry(Material.PURPLE_BED, Material.PURPLE_BED, ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_12, ProtocolVersion.MINECRAFT_1_12_2));
+			registerRemapEntry(Material.GREEN_BED, Material.GREEN_BED, ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_12, ProtocolVersion.MINECRAFT_1_12_2));
+			registerRemapEntry(Material.BROWN_BED, Material.BROWN_BED, ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_12, ProtocolVersion.MINECRAFT_1_12_2));
+			registerRemapEntry(Material.RED_BED, Material.RED_BED, ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_12, ProtocolVersion.MINECRAFT_1_12_2));
+			registerRemapEntry(Material.BLACK_BED, Material.BLACK_BED, ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_12, ProtocolVersion.MINECRAFT_1_12_2));
+
 			registerRemapEntry(Material.KNOWLEDGE_BOOK, Material.BOOK, ProtocolVersionsHelper.BEFORE_1_12);
 			registerRemapEntry(Material.IRON_NUGGET, Material.GOLD_NUGGET, ProtocolVersionsHelper.BEFORE_1_11_1);
 			registerRemapEntry(Material.SHULKER_SHELL, Material.COBBLESTONE, ProtocolVersionsHelper.BEFORE_1_11);


### PR DESCRIPTION
While i was fixing bed colors for 1.12.x clients i found another bug: when a trapped or normal chest is placed, it will show up as an ender chests instead of it's original material.